### PR TITLE
remove turbo-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "puma"
 gem "rails"
 gem "stimulus-rails"
 gem "tailwindcss-rails"
-gem "turbo-rails"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,10 +289,6 @@ GEM
     thor (1.3.1)
     tilt (2.3.0)
     timeout (0.4.1)
-    turbo-rails (2.0.5)
-      actionpack (>= 6.0.0)
-      activejob (>= 6.0.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -339,7 +335,6 @@ DEPENDENCIES
   rubocop-rails
   stimulus-rails
   tailwindcss-rails
-  turbo-rails
   tzinfo-data
   web-console
   webdrivers


### PR DESCRIPTION
Having the gem installed causes this error in Production:

```
uninitialized constant ActionCable class Turbo::StreamsChannel < ActionCable::Channel::Base ^^^^^^^^^^^ Did you mean? Rational
```

We only need the JS part of Turbo, so we can safely (🤞) remove it from the Gemfile.